### PR TITLE
Fix burnout effects to not be too long.

### DIFF
--- a/GameData/Avalanche/Configs/ACK/bole.cfg
+++ b/GameData/Avalanche/Configs/ACK/bole.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		        key = 0 0 0 0
-				key = 0.01 0.01 0 0
-				key = 10 1.5 0 0
-				key = 30 1.5 0 0
-				key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/AJ260.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/AJ260.cfg
@@ -46,16 +46,17 @@
 			ENGINEEVENTCONTROLLER
 			{
 				eventName = flameout
-				eventDuration = 60
+				eventDuration = 2
 				name = Burnout
 				eventCurve
-		        {
-		          key = 0 0 0 0
-				  key = 0.01 0.01 0 0
-				  key = 10 1.5 0 0
-				  key = 30 1.5 0 0
-				  key = 60 0 0 0
-		        }
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 			}
 			TEMPLATE
 			{

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/AJ60.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/AJ60.cfg
@@ -46,16 +46,17 @@
 			ENGINEEVENTCONTROLLER
 			{
 				eventName = flameout
-				eventDuration = 60
+				eventDuration = 2
 				name = Burnout
 				eventCurve
-		        {
-		          key = 0 0 0 0
-				  key = 0.01 0.01 0 0
-				  key = 10 1.5 0 0
-				  key = 30 1.5 0 0
-				  key = 60 0 0 0
-		        }
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 			}
 			TEMPLATE
 			{

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Castor_120.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Castor_120.cfg
@@ -46,16 +46,17 @@
 			ENGINEEVENTCONTROLLER
 			{
 				eventName = flameout
-				eventDuration = 60
+				eventDuration = 2
 				name = Burnout
 				eventCurve
-		        {
-		          key = 0 0 0 0
-				  key = 0.01 0.01 0 0
-				  key = 10 1.5 0 0
-				  key = 30 1.5 0 0
-				  key = 60 0 0 0
-		        }
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 			}
 			TEMPLATE
 			{

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Castor_2.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Castor_2.cfg
@@ -46,16 +46,17 @@
 			ENGINEEVENTCONTROLLER
 			{
 				eventName = flameout
-				eventDuration = 60
+				eventDuration = 2
 				name = Burnout
 				eventCurve
-		        {
-		          key = 0 0 0 0
-				  key = 0.01 0.01 0 0
-				  key = 10 1.5 0 0
-				  key = 30 1.5 0 0
-				  key = 60 0 0 0
-		        }
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 			}
 			TEMPLATE
 			{

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Castor_4.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Castor_4.cfg
@@ -46,16 +46,17 @@
 			ENGINEEVENTCONTROLLER
 			{
 				eventName = flameout
-				eventDuration = 60
+				eventDuration = 2
 				name = Burnout
 				eventCurve
-		        {
-		          key = 0 0 0 0
-				  key = 0.01 0.01 0 0
-				  key = 10 1.5 0 0
-				  key = 30 1.5 0 0
-				  key = 60 0 0 0
-		        }
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 			}
 			TEMPLATE
 			{

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_40_Radial.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_40_Radial.cfg
@@ -45,16 +45,17 @@
 		ENGINEEVENTCONTROLLER
 			{
 				eventName = flameout
-				eventDuration = 60
+				eventDuration = 2
 				name = Burnout
 				eventCurve
-		        {
-		          key = 0 0 0 0
-				  key = 0.01 0.01 0 0
-				  key = 10 1.5 0 0
-				  key = 30 1.5 0 0
-				  key = 60 0 0 0
-		        }
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 			}
 	    TEMPLATE
         {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_46.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_46.cfg
@@ -45,16 +45,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-              key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	    TEMPLATE
         {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_60.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_60.cfg
@@ -47,16 +47,17 @@
 			ENGINEEVENTCONTROLLER
 			{
 				eventName = flameout
-				eventDuration = 60
+				eventDuration = 2
 				name = Burnout
 				eventCurve
-		        {
-		          key = 0 0 0 0
-				  key = 0.01 0.01 0 0
-				  key = 10 1.5 0 0
-				  key = 30 1.5 0 0
-				  key = 60 0 0 0
-		        }
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 			}
 			TEMPLATE
 			{

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_60XL.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_60XL.cfg
@@ -46,16 +46,17 @@
 			ENGINEEVENTCONTROLLER
 			{
 				eventName = flameout
-				eventDuration = 60
+				eventDuration = 2
 				name = Burnout
 				eventCurve
-		        {
-		          key = 0 0 0 0
-				  key = 0.01 0.01 0 0
-				  key = 10 1.5 0 0
-				  key = 30 1.5 0 0
-				  key = 60 0 0 0
-		        }
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 			}
 			TEMPLATE
 			{

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_63XL.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/GEM_63XL.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-              key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	    TEMPLATE
         {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Joe_Sustainer.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Joe_Sustainer.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-              key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	    TEMPLATE
         {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Minuteman_Booster.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Minuteman_Booster.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-              key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	    TEMPLATE
         {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Pegasus_orion50SLX.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Pegasus_orion50SLX.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-              key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	    TEMPLATE
         {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Pegasus_orion50ST.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Pegasus_orion50ST.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-              key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	    TEMPLATE
         {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/SOLTAN_Booster.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/SOLTAN_Booster.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		   {
-            key = 0 0 0 0
-			   key = 0.01 0.01 0 0
-			   key = 10 1.5 0 0
-			   key = 30 1.5 0 0
-			   key = 60 0 0 0
-	      }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	   TEMPLATE
       {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/SRMU_Booster.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/SRMU_Booster.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		   {
-            key = 0 0 0 0
-			   key = 0.01 0.01 0 0
-			   key = 10 1.5 0 0
-			   key = 30 1.5 0 0
-			   key = 60 0 0 0
-	      }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	   TEMPLATE
       {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Scout_Algol_Inline.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Scout_Algol_Inline.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		   {
-            key = 0 0 0 0
-			   key = 0.01 0.01 0 0
-			   key = 10 1.5 0 0
-			   key = 30 1.5 0 0
-			   key = 60 0 0 0
-	      }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	   TEMPLATE
       {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Scout_Algol_Radial.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Scout_Algol_Radial.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		   {
-            key = 0 0 0 0
-			   key = 0.01 0.01 0 0
-			   key = 10 1.5 0 0
-			   key = 30 1.5 0 0
-			   key = 60 0 0 0
-	      }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	   TEMPLATE
       {

--- a/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Titan_III_Booster.cfg
+++ b/GameData/Avalanche/Configs/Bluedog_Design_Bureau/Titan_III_Booster.cfg
@@ -45,16 +45,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		   {
-            key = 0 0 0 0
-			key = 0.01 0.01 0 0
-			key = 10 1.5 0 0
-			key = 30 1.5 0 0
-			key = 60 0 0 0
-	      }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	   TEMPLATE
       {

--- a/GameData/Avalanche/Configs/CRE/Blackforest Rook Stone.cfg
+++ b/GameData/Avalanche/Configs/CRE/Blackforest Rook Stone.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		     {
-		      key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/Chrayol_Design_org/Dhruveey 220g.cfg
+++ b/GameData/Avalanche/Configs/Chrayol_Design_org/Dhruveey 220g.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 		    ventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		        key = 0 0 0 0
-			    key = 0.01 0.01 0 0
-				key = 10 1.5 0 0
-				key = 30 1.5 0 0
-				key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/Chrayol_Design_org/Dhruveey 3200.cfg
+++ b/GameData/Avalanche/Configs/Chrayol_Design_org/Dhruveey 3200.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		        key = 0 0 0 0
-			    key = 0.01 0.01 0 0
-			    key = 10 1.5 0 0
-				key = 30 1.5 0 0
-				key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/GemstoneLV/H1SRB.cfg
+++ b/GameData/Avalanche/Configs/GemstoneLV/H1SRB.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		      key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/H2/h2.cfg
+++ b/GameData/Avalanche/Configs/H2/h2.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		      key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/H2/ssb.cfg
+++ b/GameData/Avalanche/Configs/H2/ssb.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 	    	eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		      key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KNES/Ariane5SRB.cfg
+++ b/GameData/Avalanche/Configs/KNES/Ariane5SRB.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		      key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KNES/P03.cfg
+++ b/GameData/Avalanche/Configs/KNES/P03.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KNES/P10.cfg
+++ b/GameData/Avalanche/Configs/KNES/P10.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KNES/P120C.E.cfg
+++ b/GameData/Avalanche/Configs/KNES/P120C.E.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		      key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KNES/P16.cfg
+++ b/GameData/Avalanche/Configs/KNES/P16.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KNES/P35.cfg
+++ b/GameData/Avalanche/Configs/KNES/P35.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KNES/P40.cfg
+++ b/GameData/Avalanche/Configs/KNES/P40.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KNES/P80.cfg
+++ b/GameData/Avalanche/Configs/KNES/P80.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		      key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KNES/PAP.cfg
+++ b/GameData/Avalanche/Configs/KNES/PAP.cfg
@@ -47,16 +47,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/KODS/GEM_63XL.cfg
+++ b/GameData/Avalanche/Configs/KODS/GEM_63XL.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-              key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 	    TEMPLATE
         {

--- a/GameData/Avalanche/Configs/PhotonCorp/pc.cfg
+++ b/GameData/Avalanche/Configs/PhotonCorp/pc.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/PhotonCorp/pc_small.cfg
+++ b/GameData/Avalanche/Configs/PhotonCorp/pc_small.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/restock/Clydesdale.cfg
+++ b/GameData/Avalanche/Configs/restock/Clydesdale.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/restock/Thoroughbred.cfg
+++ b/GameData/Avalanche/Configs/restock/Thoroughbred.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/restock/bacc.cfg
+++ b/GameData/Avalanche/Configs/restock/bacc.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-		    {
-		      key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-		    }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/restock/flea.hammer.cfg
+++ b/GameData/Avalanche/Configs/restock/flea.hammer.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/restock/kickback.cfg
+++ b/GameData/Avalanche/Configs/restock/kickback.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/restock/mite.shrimp.cfg
+++ b/GameData/Avalanche/Configs/restock/mite.shrimp.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/restock/pollux.cfg
+++ b/GameData/Avalanche/Configs/restock/pollux.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/stock/Clydesdale.cfg
+++ b/GameData/Avalanche/Configs/stock/Clydesdale.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/stock/bacc.cfg
+++ b/GameData/Avalanche/Configs/stock/bacc.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/stock/flea.hammer.cfg
+++ b/GameData/Avalanche/Configs/stock/flea.hammer.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/stock/kickback.cfg
+++ b/GameData/Avalanche/Configs/stock/kickback.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/stock/mite.shrimp.cfg
+++ b/GameData/Avalanche/Configs/stock/mite.shrimp.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/stock/pollux.cfg
+++ b/GameData/Avalanche/Configs/stock/pollux.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/GameData/Avalanche/Configs/stock/thoroughbred.cfg
+++ b/GameData/Avalanche/Configs/stock/thoroughbred.cfg
@@ -46,16 +46,17 @@
 		ENGINEEVENTCONTROLLER
 		{
 			eventName = flameout
-			eventDuration = 60
-			name = Burnout
-			eventCurve
-	        {
-	          key = 0 0 0 0
-			  key = 0.01 0.01 0 0
-			  key = 10 1.5 0 0
-			  key = 30 1.5 0 0
-			  key = 60 0 0 0
-	        }
+			eventDuration = 2
+				name = Burnout
+				eventCurve
+	        	{
+	          		key = 0 0 0 0
+			  		key = 0.01 0.01 0 0
+			  		key = 1 1 0 0
+			  		key = 1.2 1 0 0
+  					key = 1.25 0.7 0 0
+			  		key = 1.25 0 0 0
+	        	}
 		}
 		TEMPLATE
 		{

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-## Requires: Module Manager, Waterfall, Smokescreen
+# Avalanche Plumes Continued
+**Avalanche Plumes Continued** is an update of the original [Avalanche Plumes](https://github.com/KochieBR/Avalanche-Plumes) by [KochieBR](https://github.com/KochieBR)
+This version contains a fix to plumes continuing to show up after the boosters have run out of fuel.
+
+## Dependencies: 
+- Module Manager
+- Waterfall
+- Smokescreen
 
 ## Installation Instructions:
 1. Remove SWE/RSMP

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
-Requires: Module Manager, Waterfall, Smokescreen
+## Requires: Module Manager, Waterfall, Smokescreen
 
-Instalation Instructions
-1.Remove SWE/RSMP
-2.Remove Realplume
-3.Drop the Contents Of Gamedata in your gamedata
-4.Enjoy :)
+## Installation Instructions:
+1. Remove SWE/RSMP
+2. Remove Realplume
+3. Drop the Contents Of Gamedata in your gamedata
+4. Enjoy :)
 
-Mods Currently Supported
-Artemis Construction Kit
-Chrayol Design Org
-Commonwealth Rockets
-GemstoneLV
-H2 
-KNES
-KODS
-PhotonCorp
-Restock
-SSAUCE
-Stock(Duh)
-Tantares
-
+## Mods Currently Supported:
+- Artemis Construction Kit
+- Chrayol Design Org
+- Commonwealth Rockets
+- GemstoneLV
+- H2 
+- KNES
+- KODS
+- PhotonCorp
+- Restock
+- SSAUCE
+- Stock(Duh)
+- Tantares

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Avalanche Plumes Continued
-**Avalanche Plumes Continued** is an update of the original [Avalanche Plumes](https://github.com/KochieBR/Avalanche-Plumes) by [KochieBR](https://github.com/KochieBR)
+**Avalanche Plumes Continued** is an update of the original [Avalanche Plumes](https://github.com/KochieBR/Avalanche-Plumes) by [KochieBR](https://github.com/KochieBR).
+
 This version contains a fix to plumes continuing to show up after the boosters have run out of fuel.
 
 ## Dependencies: 


### PR DESCRIPTION
I, and at least one other person, have found the current burnout effects (that last 60 seconds) to be a bit bothersome. This fixes that, and shortens it to about 2 seconds. I also have reformatted the README to make it more readable.