### PR TITLE
Configs for ACK 5-Segment RSRM booster

### DIFF
--- a/GameData/Avalanche/Configs/ACK/rsrm.cfg
+++ b/GameData/Avalanche/Configs/ACK/rsrm.cfg
@@ -1,0 +1,93 @@
+@PART[PC_5Seg_RSRM]:NEEDS[Waterfall,Benjee10_Orion,SmokeScreen,!zRealPlume]
+{
+	!EFFECTS{}
+	!MODULE[ModuleWaterfallFX],* {}
+	@MODULE[ModuleEngines*]
+	{
+		@name = ModuleEnginesFX
+		%powerEffectName = SolidSmoke
+	}
+	AvPLUME
+	{
+		name = SolidSmoke
+		transformName = thrustTransform
+		localRotation = 0,0,0
+		localPosition = 0,0,0.10
+		fixedScale = 1.35
+		energy = 2
+		speed = 1
+	}
+	 MODULE
+    {
+	    name = ModuleWaterfallFX
+	    moduleID = BOLE
+	    version = FixedRampRates
+	    ATMOSPHEREDENSITYCONTROLLER
+	    {
+			name = atmosphereDepth
+	    }
+		THROTTLECONTROLLER
+		{
+			responseRateUp = 2200
+			responseRateDown = 2200
+			engineID =
+			name = throttle
+		}
+		RANDOMNESSCONTROLLER
+		{
+			range = 0,0
+			noiseType = perlin
+			scale = 0.5
+			minimum = -0.5
+			speed = 10
+			name = Random
+			seed = 40
+		}
+		ENGINEEVENTCONTROLLER
+		{
+			eventName = flameout
+			eventDuration = 45
+			name = Burnout
+			eventCurve
+		    {
+		        key = 0 0 0 0
+				key = 0.01 0.01 0 0
+				key = 10 1.5 0 0
+				key = 30 1.5 0 0
+				key = 60 0 0 0
+		    }
+		}
+		TEMPLATE
+		{
+			templateName = SeaLevelPlume
+			overrideParentTransform = thrustTransform
+			position = 0,0,0
+            rotation = 0, 0, 0
+            scale = 1.16, 1.16, 1.4
+		}
+		TEMPLATE
+		{
+			templateName = BurnoutPlume
+			overrideParentTransform = thrustTransform
+			position = 0,0,0
+            rotation = 0, 0, 0
+            scale = 1.19, 1.19, 1.4
+		}
+		TEMPLATE
+		{
+			templateName = Burnout
+			overrideParentTransform = thrustTransform
+			position = 0,0,-0.5
+            rotation = 0, 0, 0
+            scale = 1.2, 1.2, 3
+		}
+		TEMPLATE
+		{
+			templateName = BurnoutFireball
+			overrideParentTransform = thrustTransform
+			position = 0,0,0
+            rotation = 0, 0, 0
+            scale = 0.3, 0.3, 0.25
+		}
+	}
+}

--- a/GameData/Avalanche/Configs/ACK/rsrm_nose_cone.cfg
+++ b/GameData/Avalanche/Configs/ACK/rsrm_nose_cone.cfg
@@ -1,0 +1,45 @@
+@PART[PC_Nose]:NEEDS[Waterfall,Benjee10_Orion,SmokeScreen,!zRealPlume]:AFTER[Benjee10_Orion]
+{
+	!fx_exhaustFlame_yellow_tiny = 0.0, -0.17, 0.163, 0.0, 1.0, 0.0, running
+	sound_vent_medium = engage
+	sound_rocket_mini = running
+	sound_vent_soft = disengage
+	!MODULE[ModuleWaterfallFX],* {}
+	MODULE
+    {
+		name = ModuleWaterfallFX
+		moduleID = BOLE_Sepatron
+		version = FixedRampRates
+		ATMOSPHEREDENSITYCONTROLLER
+		{
+			name = atmosphereDepth
+		}
+		THROTTLECONTROLLER
+		{
+			responseRateUp = 2200
+			responseRateDown = 2200
+			engineID =
+			name = throttle
+		}
+		RANDOMNESSCONTROLLER
+		{
+			range = 0,0
+			noiseType = perlin
+			scale = 0.5
+			minimum = -0.5
+			speed = 10
+			name = Random
+			seed = 40
+		}
+		TEMPLATE
+		{
+			templateName = RetroRocket
+			overrideParentTransform = sepMotor_thrustTransform
+			position = 0,0,0
+            rotation = 0, 0, 0
+            scale = 0.304, 0.304, 0.304
+		}
+	}
+}
+
+


### PR DESCRIPTION
Added missing configs for the 5-segment SLS booster from Artemis Construction Kit and its nose cone seperation booster part. Both based on the included BOLE config, slightly modified.